### PR TITLE
Add Components part of ECS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ coverage/
 
 # Vim swap files
 *.swp
+.session.vim

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -16,7 +16,9 @@ def FlagsForFile( filename, **kwargs ):
         filename = MatchingSourceFile(filename)
     compilation_info = database.GetCompilationInfoForFile( filename )
     if not compilation_info:
-        return None
+        return {
+                'flags': ['-Wall', '-Wextra', '-Werror', '-std=c++14']
+        }
     return {
             'flags': list(compilation_info.compiler_flags_),
         'include_paths_relative_to_dir': compilation_info.compiler_working_dir_

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Playground for new ideas, techniques and tools in the form of an OpenGL renderni
 - [x] Select a window framework (gflw)
 - [x] Setup a rendering window
 - [x] Window wrapper
-- [ ] Build verification
+- [x] Build verification
     - [x] Travis
         - [x] Linux
         - [x] Mac
@@ -28,6 +28,7 @@ Playground for new ideas, techniques and tools in the form of an OpenGL renderni
 - [ ] Engine architechture:
     - [ ] Entities
     - [ ] Components
+        - [ ] Components belong to one system
     - [ ] Systems
         - [x] Systems can be registered
         - [x] Constant lookup

--- a/README.md
+++ b/README.md
@@ -27,8 +27,16 @@ Playground for new ideas, techniques and tools in the form of an OpenGL renderni
 - [x] Testing framework
 - [ ] Engine architechture:
     - [ ] Entities
+        - [ ] can be created
+        - [ ] can be destroyed
+            - [ ] attached Components are also destroyed
+        - [ ] can have Components
     - [ ] Components
-        - [ ] Components belong to one system
+        - [x] belong to one system
+        - [ ] can be created 
+        - [ ] can be modified
+        - [ ] can be destroyed
+        - [ ] are tied to an EntityId
     - [ ] Systems
         - [x] Systems can be registered
         - [x] Constant lookup

--- a/hildring/engine/CMakeLists.txt
+++ b/hildring/engine/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.8)
 
 project(hildring C CXX)
 

--- a/hildring/engine/CMakeLists.txt
+++ b/hildring/engine/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.9)
 
 project(hildring C CXX)
 

--- a/hildring/engine/CMakeLists.txt
+++ b/hildring/engine/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 project(hildring C CXX)
 
@@ -16,12 +16,14 @@ set(SOURCES
     source/Engine.cpp
     source/Painter.cpp
     source/Window.cpp
+
+    source/ecs/Systems.cpp
 )
 
 if (MSVC)
     add_compile_options(/W4 /WX)
 else()
-    add_compile_options(-std=c++14 -Wall -Wextra -Werror)
+    add_compile_options(-Wall -Wextra -Werror)
 
     # Coverage
     set(ENABLE_COVERAGE false CACHE BOOL "Enable code coverage target")
@@ -40,6 +42,7 @@ add_dependencies(${PROJECT_NAME} glfw)
 # Tests
 set(TEST_SOURCES
     test/main.cpp
+    test/ecs/ComponentsTest.cpp
     test/ecs/SystemsTest.cpp
     test/util/IndexTest.cpp
 )
@@ -48,7 +51,12 @@ set(TEST_EXECUTABLE ${PROJECT_NAME}-tests)
 
 add_executable(${TEST_EXECUTABLE} ${TEST_SOURCES})
 
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+set_property(TARGET ${TEST_EXECUTABLE} PROPERTY CXX_STANDARD 17)
+
 target_include_directories(${TEST_EXECUTABLE} PRIVATE ../externals/catch2)
+
+target_link_libraries(${TEST_EXECUTABLE} ${PROJECT_NAME})
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND ENABLE_COVERAGE)
     target_link_libraries(${PROJECT_NAME} debug --coverage)

--- a/hildring/engine/include/ecs/Components.h
+++ b/hildring/engine/include/ecs/Components.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace ecs {
+class Components {
+public:
+    template <typename System, typename Component>
+    static bool add()
+    {
+        return true;
+    }
+};
+}

--- a/hildring/engine/include/ecs/Components.h
+++ b/hildring/engine/include/ecs/Components.h
@@ -2,11 +2,25 @@
 
 namespace ecs {
 class Components {
+
+    template <class Component>
+    class ComponentProxy {
+    public:
+        static bool exists;
+    };
+
 public:
     template <typename System, typename Component>
     static bool add()
     {
-        return true;
+        if (!ComponentProxy<Component>::exists) {
+            ComponentProxy<Component>::exists = true;
+            return true;
+        }
+        return false;
     }
 };
+
+template <class Component>
+bool Components::ComponentProxy<Component>::exists = false;
 }

--- a/hildring/engine/include/ecs/Components.h
+++ b/hildring/engine/include/ecs/Components.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ecs/Systems.h"
+
 namespace ecs {
 template <typename Component>
 class Components {
@@ -8,8 +10,8 @@ public:
     static bool link()
     {
         if (!exists) {
-            exists = true;
-            return true;
+            exists = ecs::Systems::with<System>([](System&) {});
+            return exists;
         }
         return false;
     }

--- a/hildring/engine/include/ecs/Components.h
+++ b/hildring/engine/include/ecs/Components.h
@@ -1,26 +1,23 @@
 #pragma once
 
 namespace ecs {
+template <typename Component>
 class Components {
-
-    template <class Component>
-    class ComponentProxy {
-    public:
-        static bool exists;
-    };
-
 public:
-    template <typename System, typename Component>
-    static bool add()
+    template <typename System>
+    static bool link()
     {
-        if (!ComponentProxy<Component>::exists) {
-            ComponentProxy<Component>::exists = true;
+        if (!exists) {
+            exists = true;
             return true;
         }
         return false;
     }
+
+private:
+    static bool exists;
 };
 
 template <class Component>
-bool Components::ComponentProxy<Component>::exists = false;
+bool Components<Component>::exists = false;
 }

--- a/hildring/engine/include/ecs/Components.h
+++ b/hildring/engine/include/ecs/Components.h
@@ -10,9 +10,8 @@ public:
     static bool link()
     {
         if (!exists) {
-            auto& createFn2 = createFn;
-            exists = ecs::Systems::with<System>([&createFn2](System& system) {
-                createFn2 = [&system](Component*& component) {
+            exists = ecs::Systems::with<System>([](System& system) {
+                createFn = [&system](Component*& component) {
                     return system.create(component);
                 };
             });

--- a/hildring/engine/include/ecs/Components.h
+++ b/hildring/engine/include/ecs/Components.h
@@ -10,16 +10,37 @@ public:
     static bool link()
     {
         if (!exists) {
-            exists = ecs::Systems::with<System>([](System&) {});
+            auto& createFn2 = createFn;
+            exists = ecs::Systems::with<System>([&createFn2](System& system) {
+                createFn2 = [&system](Component*& component) {
+                    return system.create(component);
+                };
+            });
             return exists;
+        }
+        return false;
+    }
+
+    template <typename Callable>
+    static bool create(Callable&& callback)
+    {
+        Component* component = nullptr;
+        createFn(component);
+        if (component) {
+            callback(*component);
+            return true;
         }
         return false;
     }
 
 private:
     static bool exists;
+    static std::function<bool(Component*&)> createFn;
 };
 
 template <class Component>
 bool Components<Component>::exists = false;
+
+template <class Component>
+std::function<bool(Component*&)> Components<Component>::createFn;
 }

--- a/hildring/engine/include/ecs/Systems.h
+++ b/hildring/engine/include/ecs/Systems.h
@@ -67,8 +67,6 @@ private:
     static SystemsContainer systems;
 };
 
-Systems::SystemsContainer Systems::systems = Systems::SystemsContainer();
-
 template <class System>
 Systems::SystemIndex Systems::SystemMapping<System>::index = Systems::SystemIndex();
 }

--- a/hildring/engine/source/ecs/Systems.cpp
+++ b/hildring/engine/source/ecs/Systems.cpp
@@ -1,0 +1,5 @@
+#include "ecs/Systems.h"
+
+namespace ecs {
+    Systems::SystemsContainer Systems::systems = Systems::SystemsContainer();
+}

--- a/hildring/engine/test/ecs/ComponentsTest.cpp
+++ b/hildring/engine/test/ecs/ComponentsTest.cpp
@@ -1,12 +1,13 @@
 #include "catch.hpp"
 
+#include "ecs/Components.h"
 #include "ecs/Systems.h"
 
 #include <string>
 
 SCENARIO("Registering components")
 {
-    GIVEN("A System is registered")
+    GIVEN("a System is registered")
     {
         struct Component {
             std::string name;
@@ -18,10 +19,13 @@ SCENARIO("Registering components")
 
         ecs::Systems::create<System>();
 
-        WHEN("Registering a Component")
+        WHEN("registering a Component")
         {
-            //            ecs::Systems::registerComponent<System, Component>();
-            CHECK(false);
+            auto result = ecs::Components::add<System, Component>();
+            THEN("result is true")
+            {
+                CHECK(result);
+            }
         }
     }
 }

--- a/hildring/engine/test/ecs/ComponentsTest.cpp
+++ b/hildring/engine/test/ecs/ComponentsTest.cpp
@@ -21,7 +21,7 @@ SCENARIO("Registering components")
 
         WHEN("registering a Component")
         {
-            auto result = ecs::Components::add<System, Component>();
+            auto result = ecs::Components<Component>::link<System>();
             THEN("result is true")
             {
                 CHECK(result);
@@ -30,7 +30,7 @@ SCENARIO("Registering components")
 
         WHEN("component is already registered")
         {
-            auto result = ecs::Components::add<System, Component>();
+            auto result = ecs::Components<Component>::link<System>();
             THEN("result is false")
             {
                 CHECK(result == false);

--- a/hildring/engine/test/ecs/ComponentsTest.cpp
+++ b/hildring/engine/test/ecs/ComponentsTest.cpp
@@ -27,6 +27,15 @@ SCENARIO("Registering components")
                 CHECK(result);
             }
         }
+
+        WHEN("component is already registered")
+        {
+            auto result = ecs::Components::add<System, Component>();
+            THEN("result is false")
+            {
+                CHECK(result == false);
+            }
+        }
     }
 }
 

--- a/hildring/engine/test/ecs/ComponentsTest.cpp
+++ b/hildring/engine/test/ecs/ComponentsTest.cpp
@@ -1,0 +1,28 @@
+#include "catch.hpp"
+
+#include "ecs/Systems.h"
+
+#include <string>
+
+SCENARIO("Registering components")
+{
+    GIVEN("A System is registered")
+    {
+        struct Component {
+            std::string name;
+        };
+
+        struct System {
+            System() {}
+        };
+
+        ecs::Systems::create<System>();
+
+        WHEN("Registering a Component")
+        {
+            //            ecs::Systems::registerComponent<System, Component>();
+            CHECK(false);
+        }
+    }
+}
+

--- a/hildring/engine/test/ecs/ComponentsTest.cpp
+++ b/hildring/engine/test/ecs/ComponentsTest.cpp
@@ -13,6 +13,16 @@ SCENARIO("Registering components")
 
     struct System {
         System() {}
+
+        bool create(Component*& c)
+        {
+            createCalled = true;
+            c = &component;
+            return true;
+        }
+
+        bool createCalled = false;
+        Component component;
     };
 
     GIVEN("System is not created")
@@ -37,6 +47,32 @@ SCENARIO("Registering components")
             THEN("linking succeeds")
             {
                 CHECK(result);
+            }
+        }
+
+        WHEN("creating Component")
+        {
+            bool didRunInit = false;
+            const auto didCreate = ecs::Components<Component>::create(
+                [&didRunInit](Component&) {
+                    didRunInit = true;
+                });
+
+            THEN("System creates it")
+            {
+                ecs::Systems::with<System>([](System& system) {
+                    CHECK(system.createCalled);
+                });
+            }
+
+            THEN("init method is called")
+            {
+                CHECK(didRunInit);
+            }
+
+            THEN("Component exists")
+            {
+                CHECK(didCreate);
             }
         }
 

--- a/hildring/engine/test/ecs/ComponentsTest.cpp
+++ b/hildring/engine/test/ecs/ComponentsTest.cpp
@@ -7,31 +7,43 @@
 
 SCENARIO("Registering components")
 {
-    GIVEN("a System is registered")
+    struct Component {
+        std::string name;
+    };
+
+    struct System {
+        System() {}
+    };
+
+    GIVEN("System is not created")
     {
-        struct Component {
-            std::string name;
-        };
+        WHEN("linking Component")
+        {
+            const auto result = ecs::Components<Component>::link<System>();
+            THEN("linking fails")
+            {
+                CHECK(result == false);
+            }
+        }
+    }
 
-        struct System {
-            System() {}
-        };
-
+    GIVEN("System is created")
+    {
         ecs::Systems::create<System>();
 
-        WHEN("registering a Component")
+        WHEN("linking a Component")
         {
-            auto result = ecs::Components<Component>::link<System>();
-            THEN("result is true")
+            const auto result = ecs::Components<Component>::link<System>();
+            THEN("linking succeeds")
             {
                 CHECK(result);
             }
         }
 
-        WHEN("component is already registered")
+        WHEN("component is already linked")
         {
-            auto result = ecs::Components<Component>::link<System>();
-            THEN("result is false")
+            const auto result = ecs::Components<Component>::link<System>();
+            THEN("linking fails")
             {
                 CHECK(result == false);
             }


### PR DESCRIPTION
A _Component_ can be linked to a _System_ using `Components<MyComponent>::link<MySystem>()`. Using `Components<MyComponent>::create()` will tell `MySystem` to create a new `MyComponent`

Linking component instances to entities is ignored at this stage.