### PR TITLE
Remove overly complicated systems registry

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,3 @@
 ignore:
     - "hildring/externals/.*"
+    - "hildring/engine/test/.*"

--- a/hildring/engine/CMakeLists.txt
+++ b/hildring/engine/CMakeLists.txt
@@ -17,7 +17,6 @@ set(SOURCES
     source/Painter.cpp
     source/Window.cpp
 
-    source/ecs/Systems.cpp
     source/util/LifetimeToken.cpp
 )
 

--- a/hildring/engine/include/ecs/Components.h
+++ b/hildring/engine/include/ecs/Components.h
@@ -17,21 +17,21 @@ public:
         if (!linked()) {
             createFn = [](const ecs::EntityId id, Component*& component) {
                 bool created = false;
-                ecs::Systems::with<System>([&created, id, &component](System& system) {
+                ecs::Systems<System>::with([&created, id, &component](System& system) {
                     created = system.create(id, component);
                 });
                 return created;
             };
             getFn = [](const ecs::EntityId id, Component*& component) {
                 bool found = false;
-                ecs::Systems::with<System>([&found, id, &component](System& system) {
+                ecs::Systems<System>::with([&found, id, &component](System& system) {
                     found = system.get(id, component);
                 });
                 return found;
             };
             destroyFn = [](const ecs::EntityId id) {
                 bool destroyed = false;
-                ecs::Systems::with<System>([&destroyed, id](System& system) {
+                ecs::Systems<System>::with([&destroyed, id](System& system) {
                     destroyed = system.destroy(id);
                 });
                 return destroyed;

--- a/hildring/engine/include/ecs/Systems.h
+++ b/hildring/engine/include/ecs/Systems.h
@@ -28,11 +28,6 @@ public:
         return false;
     }
 
-    static void reset()
-    {
-        system.reset();
-    }
-
 private:
     static System* getSystem()
     {
@@ -42,6 +37,11 @@ private:
     static bool valid()
     {
         return system != nullptr;
+    }
+
+    static void reset()
+    {
+        system.reset();
     }
 
     static std::unique_ptr<System> system;

--- a/hildring/engine/include/ecs/Systems.h
+++ b/hildring/engine/include/ecs/Systems.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "util/LifetimeToken.h"
+
 #include <memory>
 
 namespace ecs {
@@ -7,13 +9,13 @@ template <typename System>
 class Systems {
 public:
     template <typename... Args>
-    static bool create(Args&&... args)
+    static auto create(Args&&... args)
     {
         if (!valid()) {
             system = std::make_unique<System>(std::forward<Args>(args)...);
-            return true;
+            return util::LifetimeToken([]() { Systems<System>::reset(); });
         }
-        return false;
+        return util::LifetimeToken();
     }
 
     template <typename Accessor>

--- a/hildring/engine/include/ecs/Systems.h
+++ b/hildring/engine/include/ecs/Systems.h
@@ -29,11 +29,6 @@ public:
     }
 
 private:
-    static System* getSystem()
-    {
-        return system.get();
-    }
-
     static bool valid()
     {
         return system != nullptr;

--- a/hildring/engine/include/ecs/Systems.h
+++ b/hildring/engine/include/ecs/Systems.h
@@ -7,34 +7,23 @@
 #include <vector>
 
 namespace ecs {
+template <typename System>
 class Systems {
-    using SystemIndex = util::Index<unsigned long, ~0ul>;
-
-    template <class System>
-    class SystemMapping {
-    public:
-        static SystemIndex index;
-    };
-
 public:
-    template <typename System, typename... Args>
+    template <typename... Args>
     static bool create(Args&&... args)
     {
-        if (!SystemMapping<System>::index.valid()) {
-            SystemMapping<System>::index = createId();
-            systems.emplace_back(new System(std::forward<Args>(args)...), [](void* system) {
-                SystemMapping<System>::index.invalidate();
-                delete static_cast<System*>(system);
-            });
+        if (!valid()) {
+            system = std::make_unique<System>(std::forward<Args>(args)...);
             return true;
         }
         return false;
     }
 
-    template <typename System, typename Accessor>
+    template <typename Accessor>
     static bool with(Accessor&& accessor)
     {
-        if (auto system = getSystem<System>()) {
+        if (valid()) {
             accessor(*system);
             return true;
         }
@@ -43,31 +32,24 @@ public:
 
     static void reset()
     {
-        systems.clear();
+        system.reset();
     }
 
 private:
-    template <typename System>
     static System* getSystem()
     {
-        const auto index = SystemMapping<System>::index;
-        if (index.valid() && index < systems.size()) {
-            return static_cast<System*>(systems[index].get());
-        }
-        return nullptr;
+        return system.get();
     }
 
-    static SystemIndex createId()
+    static bool valid()
     {
-        return SystemIndex{ systems.size() };
+        return system != nullptr;
     }
 
-    using SystemsContainer = std::vector<std::unique_ptr<void, void (*)(void*)>>;
-
-    static SystemsContainer systems;
+    static std::unique_ptr<System> system;
 };
 
-template <class System>
-Systems::SystemIndex Systems::SystemMapping<System>::index = Systems::SystemIndex();
+template <typename System>
+std::unique_ptr<System> Systems<System>::system;
 }
 

--- a/hildring/engine/include/ecs/Systems.h
+++ b/hildring/engine/include/ecs/Systems.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#include "util/Index.h"
-
-#include <assert.h>
 #include <memory>
-#include <vector>
 
 namespace ecs {
 template <typename System>

--- a/hildring/engine/source/ecs/Systems.cpp
+++ b/hildring/engine/source/ecs/Systems.cpp
@@ -1,5 +1,2 @@
 #include "ecs/Systems.h"
 
-namespace ecs {
-    Systems::SystemsContainer Systems::systems = Systems::SystemsContainer();
-}

--- a/hildring/engine/source/ecs/Systems.cpp
+++ b/hildring/engine/source/ecs/Systems.cpp
@@ -1,2 +1,0 @@
-#include "ecs/Systems.h"
-

--- a/hildring/engine/test/ecs/ComponentsTest.cpp
+++ b/hildring/engine/test/ecs/ComponentsTest.cpp
@@ -109,7 +109,7 @@ SCENARIO("Registering components")
 
             WHEN("System is created")
             {
-                ecs::Systems::create<System>();
+                ecs::Systems<System>::create();
 
                 THEN("Component can be created")
                 {
@@ -140,7 +140,7 @@ SCENARIO("Registering components")
 
     GIVEN("System is created")
     {
-        ecs::Systems::create<System>();
+        ecs::Systems<System>::create();
 
         WHEN("linking a Component")
         {
@@ -161,7 +161,7 @@ SCENARIO("Registering components")
 
                 THEN("System creates it")
                 {
-                    ecs::Systems::with<System>([](System& system) {
+                    ecs::Systems<System>::with([](System& system) {
                         CHECK(system.createCalled);
                     });
                 }
@@ -181,7 +181,7 @@ SCENARIO("Registering components")
                     CHECK(ecs::Components<Component>::with(42, [](Component& c) {
                         c.name = "Dingo";
                     }));
-                    CHECK(ecs::Systems::with<System>([](System& s) {
+                    CHECK(ecs::Systems<System>::with([](System& s) {
                         CHECK(s.component.name == "Dingo");
                     }));
                 }
@@ -192,7 +192,7 @@ SCENARIO("Registering components")
 
                     THEN("Systems destroy is called")
                     {
-                        CHECK(ecs::Systems::with<System>([](System& s) {
+                        CHECK(ecs::Systems<System>::with([](System& s) {
                             CHECK(s.destroyCalled);
                         }));
                     }
@@ -223,7 +223,7 @@ SCENARIO("Registering components")
             bool destroy(const ecs::EntityId) { return false; }
         };
 
-        ecs::Systems::create<BadAllocSystem>();
+        ecs::Systems<BadAllocSystem>::create();
         const auto linkResult = ecs::Components<int>::link<BadAllocSystem>();
 
         WHEN("creating component")

--- a/hildring/engine/test/ecs/ComponentsTest.cpp
+++ b/hildring/engine/test/ecs/ComponentsTest.cpp
@@ -91,7 +91,7 @@ SCENARIO("Registering components")
             {
                 const auto result = ecs::Components<Component>::with(
                     42,
-                    [](Component&) { assert(false); });
+                    [](Component&) { CHECK(false); });
                 THEN("accessing fails")
                 {
                     CHECK(result == false);
@@ -109,29 +109,29 @@ SCENARIO("Registering components")
 
             WHEN("System is created")
             {
-                ecs::Systems<System>::create();
+                auto token = ecs::Systems<System>::create();
 
                 THEN("Component can be created")
                 {
                     const auto createResult = ecs::Components<Component>::create(42);
                     CHECK(createResult);
                 }
-            }
 
-            WHEN("lifetime token is moved")
-            {
+                WHEN("lifetime token is moved")
                 {
-                    const auto linkResultCopy = std::move(linkResult);
-                    THEN("link still exists")
                     {
-                        CHECK(ecs::Components<Component>::create(42) == true);
+                        const auto linkResultCopy = std::move(linkResult);
+                        THEN("link still exists")
+                        {
+                            CHECK(ecs::Components<Component>::create(42) == true);
+                        }
                     }
-                }
-                WHEN("moved token is destroyed")
-                {
-                    THEN("link is broken")
+                    WHEN("moved token is destroyed")
                     {
-                        CHECK(ecs::Components<Component>::create(42) == false);
+                        THEN("link is broken")
+                        {
+                            CHECK(ecs::Components<Component>::create(42) == false);
+                        }
                     }
                 }
             }
@@ -140,7 +140,7 @@ SCENARIO("Registering components")
 
     GIVEN("System is created")
     {
-        ecs::Systems<System>::create();
+        auto token = ecs::Systems<System>::create();
 
         WHEN("linking a Component")
         {
@@ -223,7 +223,7 @@ SCENARIO("Registering components")
             bool destroy(const ecs::EntityId) { return false; }
         };
 
-        ecs::Systems<BadAllocSystem>::create();
+        auto token = ecs::Systems<BadAllocSystem>::create();
         const auto linkResult = ecs::Components<int>::link<BadAllocSystem>();
 
         WHEN("creating component")

--- a/hildring/engine/test/ecs/SystemsTest.cpp
+++ b/hildring/engine/test/ecs/SystemsTest.cpp
@@ -94,6 +94,14 @@ SCENARIO("Adding Systems")
             {
                 CHECK(ecs::Systems<LifetimeTracker>::create(status) == true);
             }
+
+            THEN("accessing the System fails")
+            {
+                auto result = ecs::Systems<LifetimeTracker>::with([](LifetimeTracker&) {
+                    CHECK(false);
+                });
+                CHECK(result == false);
+            }
         }
     }
 

--- a/hildring/engine/test/ecs/SystemsTest.cpp
+++ b/hildring/engine/test/ecs/SystemsTest.cpp
@@ -69,7 +69,7 @@ SCENARIO("Adding Systems")
             WHEN("attempting to create the same System again")
             {
                 LifetimeStatus status2{};
-                auto result2 = ecs::Systems<LifetimeTracker>::create(status2);
+                auto token2 = ecs::Systems<LifetimeTracker>::create(status2);
 
                 THEN("the Systems constructor is not called")
                 {
@@ -78,7 +78,7 @@ SCENARIO("Adding Systems")
 
                 THEN("the token is not valid")
                 {
-                    CHECK(false == result2);
+                    CHECK(false == token2);
                 }
             }
         }

--- a/hildring/engine/test/ecs/SystemsTest.cpp
+++ b/hildring/engine/test/ecs/SystemsTest.cpp
@@ -42,7 +42,7 @@ SCENARIO("Adding Systems")
     GIVEN("a System is added")
     {
         LifetimeStatus status{};
-        auto result = ecs::Systems::create<LifetimeTracker>(status);
+        auto result = ecs::Systems<LifetimeTracker>::create(status);
 
         THEN("the System is created")
         {
@@ -67,7 +67,7 @@ SCENARIO("Adding Systems")
         WHEN("the same System is added again")
         {
             LifetimeStatus status2{};
-            auto result2 = ecs::Systems::create<LifetimeTracker>(status2);
+            auto result2 = ecs::Systems<LifetimeTracker>::create(status2);
 
             THEN("the System is not created")
             {
@@ -82,14 +82,14 @@ SCENARIO("Adding Systems")
 
         WHEN("Systems are reset")
         {
-            ecs::Systems::reset();
+            ecs::Systems<LifetimeTracker>::reset();
 
             THEN("the System is destroyed")
             {
                 CHECK(status.isDtorCalled);
             }
         }
-        ecs::Systems::reset();
+        ecs::Systems<LifetimeTracker>::reset();
     }
 
     GIVEN("arguments are passed")
@@ -108,7 +108,7 @@ SCENARIO("Adding Systems")
         WHEN("a system is added")
         {
             LifetimeStatus status{};
-            ecs::Systems::create<CopyControl>(LifetimeTracker(status));
+            ecs::Systems<CopyControl>::create(LifetimeTracker(status));
 
             THEN("arguments are not copied")
             {
@@ -129,11 +129,11 @@ SCENARIO("Adding Systems")
             int myValue = 0;
         };
 
-        ecs::Systems::create<MySystem>(42);
+        ecs::Systems<MySystem>::create(42);
 
         THEN("it can be accessed")
         {
-            CHECK(ecs::Systems::with<MySystem>([](MySystem&) {}));
+            CHECK(ecs::Systems<MySystem>::with([](MySystem&) {}));
         }
 
         WHEN("it is accessed")
@@ -141,7 +141,7 @@ SCENARIO("Adding Systems")
             THEN("accessor is invoked")
             {
                 auto run = false;
-                ecs::Systems::with<MySystem>([&run](MySystem&) {
+                ecs::Systems<MySystem>::with([&run](MySystem&) {
                     run = true;
                 });
                 CHECK(run);
@@ -149,7 +149,7 @@ SCENARIO("Adding Systems")
 
             THEN("it has the initial values")
             {
-                ecs::Systems::with<MySystem>([](MySystem& system) {
+                ecs::Systems<MySystem>::with([](MySystem& system) {
                     CHECK(42 == system.myValue);
                 });
             }
@@ -160,10 +160,10 @@ SCENARIO("Adding Systems")
             struct OtherSystem {
             };
 
-            ecs::Systems::create<OtherSystem>();
+            ecs::Systems<OtherSystem>::create();
             THEN("earlier systems can be retrieved")
             {
-                ecs::Systems::with<MySystem>([](MySystem& system) {
+                ecs::Systems<MySystem>::with([](MySystem& system) {
                     CHECK(42 == system.myValue);
                 });
             }
@@ -171,13 +171,13 @@ SCENARIO("Adding Systems")
 
         WHEN("values are set")
         {
-            ecs::Systems::with<MySystem>([](MySystem& system) {
+            ecs::Systems<MySystem>::with([](MySystem& system) {
                 system.myValue = 20;
             });
 
             THEN("they remain the same")
             {
-                ecs::Systems::with<MySystem>([](MySystem& system) {
+                ecs::Systems<MySystem>::with([](MySystem& system) {
                     CHECK(20 == system.myValue);
                 });
             }
@@ -193,13 +193,13 @@ SCENARIO("Adding Systems")
         {
             THEN("accessor check fails")
             {
-                CHECK(false == ecs::Systems::with<NoSystem>([](NoSystem&) {}));
+                CHECK(false == ecs::Systems<NoSystem>::with([](NoSystem&) {}));
             }
 
             THEN("accessor is not invoked")
             {
                 auto run = false;
-                ecs::Systems::with<NoSystem>([&run](NoSystem&) {
+                ecs::Systems<NoSystem>::with([&run](NoSystem&) {
                     run = true;
                 });
                 CHECK(run == false);

--- a/hildring/engine/test/ecs/SystemsTest.cpp
+++ b/hildring/engine/test/ecs/SystemsTest.cpp
@@ -108,7 +108,7 @@ SCENARIO("Adding Systems")
         WHEN("a system is added")
         {
             LifetimeStatus status{};
-            ecs::Systems<CopyControl>::create(LifetimeTracker(status));
+            auto token = ecs::Systems<CopyControl>::create(LifetimeTracker(status));
 
             THEN("arguments are not copied")
             {
@@ -129,7 +129,7 @@ SCENARIO("Adding Systems")
             int myValue = 0;
         };
 
-        ecs::Systems<MySystem>::create(42);
+        auto token = ecs::Systems<MySystem>::create(42);
 
         THEN("it can be accessed")
         {
@@ -160,7 +160,7 @@ SCENARIO("Adding Systems")
             struct OtherSystem {
             };
 
-            ecs::Systems<OtherSystem>::create();
+            auto token = ecs::Systems<OtherSystem>::create();
             THEN("earlier systems can be retrieved")
             {
                 ecs::Systems<MySystem>::with([](MySystem& system) {

--- a/hildring/engine/test/ecs/SystemsTest.cpp
+++ b/hildring/engine/test/ecs/SystemsTest.cpp
@@ -41,55 +41,55 @@ SCENARIO("Adding Systems")
 
     GIVEN("a System is added")
     {
+
         LifetimeStatus status{};
-        auto result = ecs::Systems<LifetimeTracker>::create(status);
-
-        THEN("the System is created")
         {
-            CHECK(status.isCtorCalled);
-        }
+            auto token = ecs::Systems<LifetimeTracker>::create(status);
 
-        THEN("result is true")
-        {
-            CHECK(result == true);
-        }
-
-        THEN("the System persists")
-        {
-            CHECK(!status.isDtorCalled);
-        }
-
-        THEN("the System is not copied")
-        {
-            CHECK(status.copyCount == 0);
-        }
-
-        WHEN("the same System is added again")
-        {
-            LifetimeStatus status2{};
-            auto result2 = ecs::Systems<LifetimeTracker>::create(status2);
-
-            THEN("the System is not created")
+            THEN("the System is created")
             {
-                CHECK(false == status2.isCtorCalled);
+                CHECK(status.isCtorCalled);
             }
 
-            THEN("result is false")
+            THEN("result is true")
             {
-                CHECK(false == result2);
+                CHECK(token == true);
+            }
+
+            THEN("the System persists")
+            {
+                CHECK(!status.isDtorCalled);
+            }
+
+            THEN("the System is not copied")
+            {
+                CHECK(status.copyCount == 0);
+            }
+
+            WHEN("the same System is added again")
+            {
+                LifetimeStatus status2{};
+                auto result2 = ecs::Systems<LifetimeTracker>::create(status2);
+
+                THEN("the System is not created")
+                {
+                    CHECK(false == status2.isCtorCalled);
+                }
+
+                THEN("result is false")
+                {
+                    CHECK(false == result2);
+                }
             }
         }
 
-        WHEN("Systems are reset")
+        WHEN("token expires")
         {
-            ecs::Systems<LifetimeTracker>::reset();
-
             THEN("the System is destroyed")
             {
                 CHECK(status.isDtorCalled);
             }
         }
-        ecs::Systems<LifetimeTracker>::reset();
     }
 
     GIVEN("arguments are passed")

--- a/hildring/engine/test/ecs/SystemsTest.cpp
+++ b/hildring/engine/test/ecs/SystemsTest.cpp
@@ -173,7 +173,7 @@ SCENARIO("Adding Systems")
             struct OtherSystem {
             };
 
-            auto token = ecs::Systems<OtherSystem>::create();
+            auto token2 = ecs::Systems<OtherSystem>::create();
             THEN("earlier systems can be retrieved")
             {
                 ecs::Systems<MySystem>::with([](MySystem& system) {

--- a/hildring/engine/test/ecs/SystemsTest.cpp
+++ b/hildring/engine/test/ecs/SystemsTest.cpp
@@ -39,44 +39,44 @@ SCENARIO("Adding Systems")
         LifetimeStatus& status;
     };
 
-    GIVEN("a System is added")
+    GIVEN("a System is created")
     {
 
         LifetimeStatus status{};
         {
             auto token = ecs::Systems<LifetimeTracker>::create(status);
 
-            THEN("the System is created")
+            THEN("the Systems constructor is called")
             {
                 CHECK(status.isCtorCalled);
             }
 
-            THEN("result is true")
+            THEN("the token returned is valid")
             {
                 CHECK(token == true);
             }
 
-            THEN("the System persists")
+            THEN("the Systems destructor has not been called")
             {
                 CHECK(!status.isDtorCalled);
             }
 
-            THEN("the System is not copied")
+            THEN("the System has not been copied")
             {
                 CHECK(status.copyCount == 0);
             }
 
-            WHEN("the same System is added again")
+            WHEN("attempting to create the same System again")
             {
                 LifetimeStatus status2{};
                 auto result2 = ecs::Systems<LifetimeTracker>::create(status2);
 
-                THEN("the System is not created")
+                THEN("the Systems constructor is not called")
                 {
                     CHECK(false == status2.isCtorCalled);
                 }
 
-                THEN("result is false")
+                THEN("the token is not valid")
                 {
                     CHECK(false == result2);
                 }
@@ -88,6 +88,11 @@ SCENARIO("Adding Systems")
             THEN("the System is destroyed")
             {
                 CHECK(status.isDtorCalled);
+            }
+
+            THEN("the System can be created again")
+            {
+                CHECK(ecs::Systems<LifetimeTracker>::create(status) == true);
             }
         }
     }
@@ -117,7 +122,7 @@ SCENARIO("Adding Systems")
         }
     }
 
-    GIVEN("a system is added")
+    GIVEN("a System is created")
     {
         struct MySystem {
             MySystem() {}


### PR DESCRIPTION
- Make Systems a templated class containing the system instance instead of containing a registry of Systems. This simplifies the code a lot and there was no gain to looking up systems by Id.
- Make Systems use scope enabled by `util::LifetimeToken`